### PR TITLE
gemspec: Explicitly empty executables list

### DIFF
--- a/abbrev.gemspec
+++ b/abbrev.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.executables   = []
   spec.require_paths = ["lib"]
 end


### PR DESCRIPTION
This PR was added for clarity: the reader can quickly figure out that there are none.