### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ 3.0, 2.7, 2.6, 2.5, head ]
+        ruby: [ 3.1, '3.0', 2.7, 2.6, 2.5, head ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
We also quote the 3.0, to ensure that CI runs a 3.0.x version for this entry.  If unquoted, 3.0 will round to 3 and it will load the latest 3.x version.  At this time that is 3.1.0, which is not what's intended.