### PR TITLE
Expose Abbrev::VERSION

### DIFF
--- a/abbrev.gemspec
+++ b/abbrev.gemspec
@@ -1,6 +1,13 @@
+name = File.basename(__FILE__, ".gemspec")
+version = ["lib", Array.new(name.count("-")+1, ".").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+    /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+  end rescue nil
+end
+
 Gem::Specification.new do |spec|
-  spec.name          = "abbrev"
-  spec.version       = "0.1.1"
+  spec.name          = name
+  spec.version       = version
   spec.authors       = ["Akinori MUSHA"]
   spec.email         = ["knu@idaemons.org"]
 

--- a/lib/abbrev.rb
+++ b/lib/abbrev.rb
@@ -48,6 +48,8 @@
 
 module Abbrev
 
+  VERSION = "0.1.1"
+
   # Given a set of strings, calculate the set of unambiguous abbreviations for
   # those strings, and return a hash where the keys are all the possible
   # abbreviations and the values are the full strings.

--- a/lib/abbrev.rb
+++ b/lib/abbrev.rb
@@ -47,7 +47,6 @@
 #     "w"       => "winter" }
 
 module Abbrev
-
   VERSION = "0.1.1"
 
   # Given a set of strings, calculate the set of unambiguous abbreviations for


### PR DESCRIPTION
This is same reason as https://github.com/ruby/syslog/pull/5#issue-1677774329