### PR TITLE
Add RBS signature and testing

### DIFF
--- a/.github/workflows/sig.yml
+++ b/.github/workflows/sig.yml
@@ -1,0 +1,20 @@
+name: sig
+
+on: [push, pull_request]
+
+jobs:
+  sig:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+      - name: Install dependencies
+        run: |
+          bundle config set with 'sig'
+          bundle install
+      - name: Run RBS test, annotate and confirm
+        run: bundle exec rake rbs:{test,annotate,confirm}

--- a/.github/workflows/sig.yml
+++ b/.github/workflows/sig.yml
@@ -5,6 +5,8 @@ on: [push, pull_request]
 jobs:
   sig:
     runs-on: "ubuntu-latest"
+    env:
+      BUNDLE_WITH: sig
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby
@@ -12,9 +14,5 @@ jobs:
         with:
           bundler-cache: true
           ruby-version: ruby
-      - name: Install dependencies
-        run: |
-          bundle config set with 'sig'
-          bundle install
-      - name: Run RBS test, annotate and confirm
-        run: bundle exec rake rbs:{test,annotate,confirm}
+      - name: Run RBS tests
+        run: bundle exec rake rbs:test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Install dependencies
-      run: bundle install
+      run: |
+        bundle config set without 'sig'
+        bundle install
     - name: Run test
       run: rake test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
           - { os: windows-latest, ruby: truffleruby-head }
           - { os: windows-latest, ruby: truffleruby }
     runs-on: ${{ matrix.os }}
+    env:
+      BUNDLE_WITHOUT: sig
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby
@@ -28,7 +30,6 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
     - name: Install dependencies
       run: |
-        bundle config set without 'sig'
         bundle install
     - name: Run test
       run: rake test

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source "https://rubygems.org"
 
 gem "rake"
 gem "test-unit"
+
+group :sig do
+  gem "rbs"
+  gem "rdoc"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,24 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList["test/**/test_*.rb"]
 end
 
+namespace :rbs do
+  task :test do
+    sh "ruby -I lib test_sig/test_abbrev.rb"
+  end
+
+  task :annotate do
+    require "tmpdir"
+
+    Dir.mktmpdir do |tmpdir|
+      sh("rdoc --ri --output #{tmpdir}/doc --root=. lib")
+      sh("rbs annotate --no-system --no-gems --no-site --no-home -d #{tmpdir}/doc sig")
+    end
+  end
+
+  task :confirm do
+    puts "Testing if RBS docs are updated with respect to RDoc"
+    sh "git diff --exit-code sig/"
+  end
+end
+
 task :default => :test

--- a/Rakefile
+++ b/Rakefile
@@ -20,11 +20,6 @@ namespace :rbs do
       sh("rbs annotate --no-system --no-gems --no-site --no-home -d #{tmpdir}/doc sig")
     end
   end
-
-  task :confirm do
-    puts "Testing if RBS docs are updated with respect to RDoc"
-    sh "git diff --exit-code sig/"
-  end
 end
 
 task :default => :test

--- a/abbrev.gemspec
+++ b/abbrev.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = spec.homepage + "/releases"
 
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|test_sig|spec|features|\.github)/}) }
   end
   spec.bindir        = "exe"
   spec.executables   = []

--- a/sig/abbrev.rbs
+++ b/sig/abbrev.rbs
@@ -1,0 +1,66 @@
+# <!-- rdoc-file=lib/abbrev.rb -->
+# Calculates the set of unambiguous abbreviations for a given set of strings.
+#
+#     require 'abbrev'
+#     require 'pp'
+#
+#     pp Abbrev.abbrev(['ruby'])
+#     #=>  {"ruby"=>"ruby", "rub"=>"ruby", "ru"=>"ruby", "r"=>"ruby"}
+#
+#     pp Abbrev.abbrev(%w{ ruby rules })
+#
+# *Generates:*
+#     { "ruby"  =>  "ruby",
+#       "rub"   =>  "ruby",
+#       "rules" =>  "rules",
+#       "rule"  =>  "rules",
+#       "rul"   =>  "rules" }
+#
+# It also provides an array core extension, Array#abbrev.
+#
+#     pp %w{ summer winter }.abbrev
+#
+# *Generates:*
+#     { "summer"  => "summer",
+#       "summe"   => "summer",
+#       "summ"    => "summer",
+#       "sum"     => "summer",
+#       "su"      => "summer",
+#       "s"       => "summer",
+#       "winter"  => "winter",
+#       "winte"   => "winter",
+#       "wint"    => "winter",
+#       "win"     => "winter",
+#       "wi"      => "winter",
+#       "w"       => "winter" }
+#
+module Abbrev
+  # <!--
+  #   rdoc-file=lib/abbrev.rb
+  #   - abbrev(words, pattern = nil)
+  # -->
+  # Given a set of strings, calculate the set of unambiguous abbreviations for
+  # those strings, and return a hash where the keys are all the possible
+  # abbreviations and the values are the full strings.
+  #
+  # Thus, given `words` is "car" and "cone", the keys pointing to "car" would be
+  # "ca" and "car", while those pointing to "cone" would be "co", "con", and
+  # "cone".
+  #
+  #     require 'abbrev'
+  #
+  #     Abbrev.abbrev(%w{ car cone })
+  #     #=> {"ca"=>"car", "con"=>"cone", "co"=>"cone", "car"=>"car", "cone"=>"cone"}
+  #
+  # The optional `pattern` parameter is a pattern or a string. Only input strings
+  # that match the pattern or start with the string are included in the output
+  # hash.
+  #
+  #     Abbrev.abbrev(%w{car box cone crab}, /b/)
+  #     #=> {"box"=>"box", "bo"=>"box", "b"=>"box", "crab" => "crab"}
+  #
+  #     Abbrev.abbrev(%w{car box cone}, 'ca')
+  #     #=> {"car"=>"car", "ca"=>"car"}
+  #
+  def self?.abbrev: (Array[String], ?String | Regexp | nil) -> Hash[String, String]
+end

--- a/sig/array.rbs
+++ b/sig/array.rbs
@@ -1,0 +1,26 @@
+%a{annotate:rdoc:skip}
+class Array[unchecked out Elem]
+  # <!--
+  #   rdoc-file=lib/abbrev.rb
+  #   - abbrev(pattern = nil)
+  # -->
+  # Calculates the set of unambiguous abbreviations for the strings in `self`.
+  #
+  #     require 'abbrev'
+  #     %w{ car cone }.abbrev
+  #     #=> {"car"=>"car", "ca"=>"car", "cone"=>"cone", "con"=>"cone", "co"=>"cone"}
+  #
+  # The optional `pattern` parameter is a pattern or a string. Only input strings
+  # that match the pattern or start with the string are included in the output
+  # hash.
+  #
+  #     %w{ fast boat day }.abbrev(/^.a/)
+  #     #=> {"fast"=>"fast", "fas"=>"fast", "fa"=>"fast", "day"=>"day", "da"=>"day"}
+  #
+  #     Abbrev.abbrev(%w{car box cone}, "ca")
+  #     #=> {"car"=>"car", "ca"=>"car"}
+  #
+  # See also Abbrev.abbrev
+  #
+  def abbrev: (?String | Regexp | nil) -> Hash[String, String]
+end

--- a/test_sig/test_abbrev.rb
+++ b/test_sig/test_abbrev.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'abbrev'
+require 'test/unit'
+require 'rbs/unit_test'
+
+class AbbrevSingletonTest < Test::Unit::TestCase
+  include RBS::UnitTest::TypeAssertions
+
+  library 'abbrev'
+  testing "singleton(::Abbrev)"
+
+  def test_abbrev
+    assert_send_type '(Array[String]) -> Hash[String, String]',
+                     Abbrev, :abbrev, %w[car cone]
+    assert_send_type '(Array[String], Regexp) -> Hash[String, String]',
+                     Abbrev, :abbrev, %w{car box cone crab}, /b/
+    assert_send_type '(Array[String], String) -> Hash[String, String]',
+                     Abbrev, :abbrev, %w{car box cone}, 'ca'
+  end
+end
+
+class AbbrevArrayInstanceTest < Test::Unit::TestCase
+  include RBS::UnitTest::TypeAssertions
+
+  library 'abbrev'
+  testing "::Array[String]"
+
+  def test_array
+    assert_send_type '() -> Hash[String, String]',
+                     %w{ car cone }, :abbrev
+    assert_send_type '(Regexp) -> Hash[String, String]',
+                     %w{ fast boat day }, :abbrev, /^.a/
+  end
+end


### PR DESCRIPTION
I propose managing the signatures in a ruby/abbrev repository instead of ruby/gem_rbs_collection.

### Background

abbrev is a bundled gem.  
Until now, its signatures were managed in the RBS repository, but bundled gems are now expected to be maintained either in gem_rbs_collection or in the gem itself.

### Benefit

We can provide users with signatures that follow the Ruby code perfectly.

### Signatures

Original: https://github.com/ruby/rbs/tree/e7982676710c3c57527402a6d36b7b344f8caa74/stdlib/abbrev/0
Current: https://github.com/ruby/gem_rbs_collection/tree/8e101ffc685036c676be54984ec5fcdf825db280/gems/abbrev/0.1
Once this change is released, rbs will automatically give preference to the gem's signature.

### Testing of signatures

No modifications have been made to existing Ruby tests.
I have rewritten a new test for signatures.
It is sufficient to test signatures only with the latest version of Ruby.

### Comment of signatures

Ruby comments and rbs comments are synchronized using the `rake rbs:annotate` command.
After operating with [ruby/base64](https://github.com/ruby/base64), I received feedback that it's not necessary to check comment updates with CI, and that updating them at arbitrary timings seems sufficient.